### PR TITLE
Override for provided mesos duration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ pkgs=$(shell $(GO) list ./... | egrep -v ("vendor)")
 
 export DOCKERHUB_REPO=dragnet
 export DOCKERHUB_USER=mslocrian
-export SAUSAGE_VERSION=0.0.12
+export SAUSAGE_VERSION=0.0.14
 export VERSION=v$(SAUSAGE_VERSION)
 
 build:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,8 +198,9 @@ func (s *SafeConfig) StartAutoDiscoverers() {
 							break
 						case <-time.After(taskTimeout * time.Second):
 							log.Debugf("Autodiscovery: marathon task fetch timeout. continuing...")
+                    refreshInterval := s.C.AutoTargets[manager].RefreshInterval
+                    log.Debugf("refreshInterval.String()==%#v", refreshInterval.String())
 							continue
-
 						}
 						newTargets := make(map[string]bool)
 						var listTargets []string
@@ -224,6 +225,9 @@ func (s *SafeConfig) StartAutoDiscoverers() {
 					if stopDiscoverer() {
 						break
 					}
+
+                    refreshInterval := s.C.AutoTargets[manager].RefreshInterval
+                    refreshInterval.String()
 					time.Sleep(taskRefresh * time.Second)
 				}
 				return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,8 +81,17 @@ func (s *SafeConfig) ReloadConfig(cfg string) error {
 		if strings.ToLower(key) == "dcos" {
 			atConfig := c.AutoTargets[key]
 
+			// stegen - find a better way to override the refresh
+			// interval. we want to tune it way down, since we're
+			// overriding a sleep elsewhere.
+			/*
+				sdConfig := marathon.SDConfig{Servers: atConfig.Servers,
+					RefreshInterval:  atConfig.RefreshInterval,
+					HTTPClientConfig: atConfig.HTTPClientConfig}
+			*/
+			duration, _ := model.ParseDuration("1s")
 			sdConfig := marathon.SDConfig{Servers: atConfig.Servers,
-				RefreshInterval:  atConfig.RefreshInterval,
+				RefreshInterval:  duration,
 				HTTPClientConfig: atConfig.HTTPClientConfig}
 			promlogLevel := &promlog.AllowedLevel{}
 			promlogLevel.Set("debug")
@@ -185,8 +194,10 @@ func (s *SafeConfig) StartAutoDiscoverers() {
 						case <-ts:
 							targetGroups = <-ts
 							cancel()
+							log.Debugf("Autodiscovery: marathon task fetch complete.")
 							break
 						case <-time.After(taskTimeout * time.Second):
+							log.Debugf("Autodiscovery: marathon task fetch timeout. continuing...")
 							continue
 
 						}


### PR DESCRIPTION
This is a bit cheeky, but with how we are manually running the `discovery.Run()`, I can be timing out the run before the refresh_interval runs. That means our inventory can be questionable. 

Instead, force it down to 1s, and we'll want to change the time.Sleep to what the refresh_interval is, instead. Make the taskTimeout longer.